### PR TITLE
Add proper handling for dates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    name: ${{ matrix.toolchain }} / clippy
+    name: clippy
     permissions:
       contents: read
       checks: write
@@ -39,6 +39,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          args: --workspace --all-features
 
   rust-tests:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api"]
 serde = { version = "1.0", features = ["derive"] }
 
 [features]
-dates = []
+dates = ["serde/derive"]
 
 [workspace]
 members = ["test_macro/native", "tests/native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,8 @@ features = ["default-panic-hook", "napi-6", "try-catch-api", "event-queue-api"]
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 
+[features]
+dates = []
+
 [workspace]
 members = ["test_macro/native", "tests/native"]

--- a/src/dates.rs
+++ b/src/dates.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/dates.rs
+++ b/src/dates.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct JsDate {
+    __neon_serde_date: f64,
+}
+
+impl JsDate {
+    pub fn as_millis(&self) -> i64 {
+        self.__neon_serde_date as i64
+    }
+
+    pub fn from_millis(millis: i64) -> Self {
+        Self {
+            __neon_serde_date: millis as f64,
+        }
+    }
+}

--- a/src/dates.rs
+++ b/src/dates.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct JsDate {

--- a/src/de.rs
+++ b/src/de.rs
@@ -2,6 +2,7 @@
 
 use neon::prelude::*;
 use neon::types::buffer::TypedArray;
+use neon::types::JsDate;
 use serde;
 use serde::de::{
     DeserializeOwned, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, Unexpected, VariantAccess,
@@ -82,6 +83,14 @@ impl<'x, 'd, 'a, 'j, C: Context<'j>> serde::de::Deserializer<'x>
             }
         } else if let Ok(_val) = self.input.downcast::<JsBuffer, C>(self.cx) {
             self.deserialize_bytes(visitor)
+        } else if let Ok(date) = self.input.downcast::<JsDate, C>(self.cx) {
+            // this is needed so that when we can serialize the date back into a JS object
+            let date = date.value(self.cx);
+            let date = self.cx.number(date);
+            let value = self.cx.empty_object();
+            value.set(self.cx, "__neon_serde_date", date)?;
+            let mut deserializer = JsObjectAccess::new(self.cx, value)?;
+            visitor.visit_map(&mut deserializer)
         } else if let Ok(val) = self.input.downcast::<JsArray, C>(self.cx) {
             let mut deserializer = JsArrayAccess::new(self.cx, val);
             visitor.visit_seq(&mut deserializer)
@@ -260,7 +269,10 @@ impl<'x, 'a, 'j, C: Context<'j>> MapAccess<'x> for JsObjectAccess<'a, 'j, C> {
         }
         let prop_name = self.prop_names.get::<JsString, _, _>(self.cx, self.idx)?;
         let value = self.input.get(self.cx, prop_name)?;
-
+        let global = self.cx.global();
+        let console = global.get::<JsObject, _ , _>(self.cx, "console")?;
+            console.get::<JsFunction, _, _>(self.cx, "log")?
+            .call(self.cx, global, vec![value])?;
         self.idx += 1;
         let mut de = Deserializer::new(self.cx, value);
         let res = seed.deserialize(&mut de)?;

--- a/src/de.rs
+++ b/src/de.rs
@@ -270,8 +270,9 @@ impl<'x, 'a, 'j, C: Context<'j>> MapAccess<'x> for JsObjectAccess<'a, 'j, C> {
         let prop_name = self.prop_names.get::<JsString, _, _>(self.cx, self.idx)?;
         let value = self.input.get(self.cx, prop_name)?;
         let global = self.cx.global();
-        let console = global.get::<JsObject, _ , _>(self.cx, "console")?;
-            console.get::<JsFunction, _, _>(self.cx, "log")?
+        let console = global.get::<JsObject, _, _>(self.cx, "console")?;
+        console
+            .get::<JsFunction, _, _>(self.cx, "log")?
             .call(self.cx, global, vec![value])?;
         self.idx += 1;
         let mut de = Deserializer::new(self.cx, value);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// This type of object is not supported
     #[error("Not Implemented {0}")]
     NotImplemented(&'static str),
+    /// This type of object is not supported
+    #[error("{0}")]
+    DateError(#[from] neon::types::DateError),
     /// A JS exception was thrown
     #[error("JS exception")]
     Js(neon::result::Throw),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ pub mod de;
 pub mod errors;
 pub mod ser;
 
-mod macros;
 #[cfg(feature = "dates")]
 pub mod dates;
+mod macros;
 
 pub use de::{from_value, from_value_opt};
 pub use ser::to_value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod errors;
 pub mod ser;
 
 mod macros;
+#[cfg(feature = "dates")]
+pub mod dates;
 
 pub use de::{from_value, from_value_opt};
 pub use ser::to_value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use ser::to_value;
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::let_unit_value)]
     use neon::prelude::*;
 
     use super::*;
@@ -25,10 +26,9 @@ mod tests {
         fn check<'j>(mut cx: FunctionContext<'j>) -> JsResult<'j, JsValue> {
             let result: () = {
                 let arg: Handle<'j, JsValue> = cx.argument::<JsValue>(0)?;
-                let () = from_value(&mut cx, arg)
+                from_value(&mut cx, arg)
                     .or_else(|e| cx.throw_error(e.to_string()))
-                    .unwrap();
-                ()
+                    .unwrap()
             };
             let result: Handle<'j, JsValue> = to_value(&mut cx, &result)
                 .or_else(|e| cx.throw_error(e.to_string()))
@@ -44,9 +44,9 @@ mod tests {
         fn check<'j>(mut cx: FunctionContext<'j>) -> JsResult<'j, JsValue> {
             let result: () = {
                 let arg: Option<Handle<'j, JsValue>> = cx.argument_opt(0);
-                let () = from_value_opt(&mut cx, arg)
+                from_value_opt(&mut cx, arg)
                     .or_else(|e| cx.throw_error(e.to_string()))
-                    .unwrap();
+                    .unwrap()
             };
             let result: Handle<'j, JsValue> = to_value(&mut cx, &result)
                 .or_else(|e| cx.throw_error(e.to_string()))

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -16,7 +16,10 @@ fn as_num<T: num::cast::NumCast, OutT: num::cast::NumCast>(n: T) -> LibResult<Ou
     }
 }
 
-fn to_date<'c>(cx: &mut impl Context<'c>, value: Handle<'c, JsValue>) -> Result<Handle<'c, JsObject>, Error> {
+fn to_date<'c>(
+    cx: &mut impl Context<'c>,
+    value: Handle<'c, JsValue>,
+) -> Result<Handle<'c, JsObject>, Error> {
     let value = value.downcast::<JsNumber, _>(cx).unwrap();
     let value = value.value(cx);
     let date = cx.date(value)?;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -16,6 +16,14 @@ fn as_num<T: num::cast::NumCast, OutT: num::cast::NumCast>(n: T) -> LibResult<Ou
     }
 }
 
+fn to_date<'c>(cx: &mut impl Context<'c>, value: Handle<'c, JsValue>) -> Result<Handle<'c, JsObject>, Error> {
+    let value = value.downcast::<JsNumber, _>(cx).unwrap();
+    let value = value.value(cx);
+    let date = cx.date(value)?;
+    let obj = date.downcast_or_throw::<JsObject, _>(cx)?;
+    Ok(obj)
+}
+
 /// Converts a value of type `V` to a `JsValue`
 ///
 /// # Errors
@@ -472,9 +480,20 @@ where
     where
         T: Serialize,
     {
-        let key: Handle<'j, JsValue> = self.key_holder.get(&mut *self.cx, "key")?;
-        let value_obj = to_value(self.cx, value)?;
-        self.object.set(self.cx, key, value_obj)?;
+        let key = self.key_holder.get::<JsString, _, _>(&mut *self.cx, "key");
+        let key = key.map(|key| key.value(self.cx) == "__neon_serde_date");
+        if key.unwrap_or(false) {
+            // this round-trip is necessary because the date constructor expects a number
+            // and we have a &T: Serialize
+            // We extract the number by converting T to JsValue and then downcasting it to JsNumber
+            let value = to_value(self.cx, value)?;
+            self.object = to_date(self.cx, value)?;
+        } else {
+            let key: Handle<'j, JsValue> = self.key_holder.get(&mut *self.cx, "key")?;
+            let value_obj = to_value(self.cx, value)?;
+            self.object.set(self.cx, key, value_obj)?;
+        }
+
         Ok(())
     }
 
@@ -514,7 +533,11 @@ where
         T: Serialize,
     {
         let value = to_value(self.cx, value)?;
-        self.object.set(self.cx, key, value)?;
+        if key == "__neon_serde_date" {
+            self.object = to_date(self.cx, value)?
+        } else {
+            self.object.set(self.cx, key, value)?;
+        }
         Ok(())
     }
 

--- a/tests/__tests__/get_values.js
+++ b/tests/__tests__/get_values.js
@@ -111,6 +111,26 @@ describe('all values ok', () => {
         native.expect_obj(obj);
     });
 
+
+    it('rt_dates_js_rust_js', () => {
+        const o = {
+            date2: new Date()
+        }
+        const o2 = native.roundtrip_with_dates(o);
+        expect(o).toEqual(o2);
+    });
+
+    it('rt_js_rust_js_serde_json_value', () => {
+        const o = {
+            age: 10,
+            gender: 'male',
+            name: 'name2',
+            date2: new Date()
+        }
+        const o2 = native.roundtrip_serde_json_value(o);
+        expect(o).toEqual(o2);
+    });
+
     it('rt_js_rust_js', () => {
         const o = {
             a: 1,

--- a/tests/native/Cargo.toml
+++ b/tests/native/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["dylib"]
 [dependencies]
 serde_json = "1.0.95"
 serde = { version = "1.0.159", features = ["derive"] }
-neon-serde = { path = "../..", package = "neon-serde2" }
+neon-serde = { path = "../..", package = "neon-serde2", features = ["dates"] }
 serde_bytes = "0.11.9"
 
 [dependencies.neon]

--- a/tests/native/src/lib.rs
+++ b/tests/native/src/lib.rs
@@ -162,11 +162,11 @@ make_expect!(
 fn roundtrip_object(mut cx: FunctionContext) -> JsResult<JsValue> {
     let arg0 = cx.argument::<JsValue>(0)?;
 
-    let de_serialized: AnObjectTwo = neon_serde::from_value(&mut cx, arg0)
-        .or_else(|e| cx.throw_error(e.to_string()))?;
+    let de_serialized: AnObjectTwo =
+        neon_serde::from_value(&mut cx, arg0).or_else(|e| cx.throw_error(e.to_string()))?;
 
-    let handle = neon_serde::to_value(&mut cx, &de_serialized)
-        .or_else(|e| cx.throw_error(e.to_string()))?;
+    let handle =
+        neon_serde::to_value(&mut cx, &de_serialized).or_else(|e| cx.throw_error(e.to_string()))?;
 
     Ok(handle)
 }
@@ -178,25 +178,23 @@ struct RoundtripWithDates {
 fn roundtrip_with_dates(mut cx: FunctionContext) -> JsResult<JsValue> {
     let arg0 = cx.argument::<JsValue>(0)?;
 
-    let de_serialized: RoundtripWithDates = neon_serde::from_value(&mut cx, arg0)
-        .or_else(|e| cx.throw_error(e.to_string()))?;
+    let de_serialized: RoundtripWithDates =
+        neon_serde::from_value(&mut cx, arg0).or_else(|e| cx.throw_error(e.to_string()))?;
 
-    let handle = neon_serde::to_value(&mut cx, &de_serialized)
-        .or_else(|e| cx.throw_error(e.to_string()))?;
+    let handle =
+        neon_serde::to_value(&mut cx, &de_serialized).or_else(|e| cx.throw_error(e.to_string()))?;
 
     Ok(handle)
 }
 
-
-
 fn roundtrip_serde_json_value(mut cx: FunctionContext) -> JsResult<JsValue> {
     let arg0 = cx.argument::<JsValue>(0)?;
 
-    let de_serialized: serde_json::Value = neon_serde::from_value(&mut cx, arg0)
-        .or_else(|e| cx.throw_error(e.to_string()))?;
+    let de_serialized: serde_json::Value =
+        neon_serde::from_value(&mut cx, arg0).or_else(|e| cx.throw_error(e.to_string()))?;
 
-    let handle = neon_serde::to_value(&mut cx, &de_serialized)
-        .or_else(|e| cx.throw_error(e.to_string()))?;
+    let handle =
+        neon_serde::to_value(&mut cx, &de_serialized).or_else(|e| cx.throw_error(e.to_string()))?;
 
     Ok(handle)
 }

--- a/tests/native/src/lib.rs
+++ b/tests/native/src/lib.rs
@@ -75,7 +75,7 @@ make_test!(make_map, {
 });
 
 make_test!(make_object, {
-    let value = AnObjectTwo {
+    AnObjectTwo {
         a: 1,
         b: vec![1, 2],
         c: "abc".into(),
@@ -96,11 +96,10 @@ make_test!(make_object, {
         p: vec![1., 2., 3.5],
         q: 999,
         r: 333,
-    };
-    value
+    }
 });
 
-const NUMBER_BYTES: &'static [u8] = &[255u8, 254, 253];
+const NUMBER_BYTES: &[u8] = &[255u8, 254, 253];
 
 make_test!(make_buff, { serde_bytes::Bytes::new(NUMBER_BYTES) });
 

--- a/tests/native/src/lib.rs
+++ b/tests/native/src/lib.rs
@@ -163,11 +163,41 @@ fn roundtrip_object(mut cx: FunctionContext) -> JsResult<JsValue> {
     let arg0 = cx.argument::<JsValue>(0)?;
 
     let de_serialized: AnObjectTwo = neon_serde::from_value(&mut cx, arg0)
-        .or_else(|e| cx.throw_error(e.to_string()))
-        .unwrap();
+        .or_else(|e| cx.throw_error(e.to_string()))?;
+
     let handle = neon_serde::to_value(&mut cx, &de_serialized)
-        .or_else(|e| cx.throw_error(e.to_string()))
-        .unwrap();
+        .or_else(|e| cx.throw_error(e.to_string()))?;
+
+    Ok(handle)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RoundtripWithDates {
+    date2: neon_serde::dates::JsDate,
+}
+fn roundtrip_with_dates(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let arg0 = cx.argument::<JsValue>(0)?;
+
+    let de_serialized: RoundtripWithDates = neon_serde::from_value(&mut cx, arg0)
+        .or_else(|e| cx.throw_error(e.to_string()))?;
+
+    let handle = neon_serde::to_value(&mut cx, &de_serialized)
+        .or_else(|e| cx.throw_error(e.to_string()))?;
+
+    Ok(handle)
+}
+
+
+
+fn roundtrip_serde_json_value(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let arg0 = cx.argument::<JsValue>(0)?;
+
+    let de_serialized: serde_json::Value = neon_serde::from_value(&mut cx, arg0)
+        .or_else(|e| cx.throw_error(e.to_string()))?;
+
+    let handle = neon_serde::to_value(&mut cx, &de_serialized)
+        .or_else(|e| cx.throw_error(e.to_string()))?;
+
     Ok(handle)
 }
 
@@ -187,5 +217,7 @@ register_module!(mut m, {
     m.export_function("expect_buffer", expect_buffer)?;
 
     m.export_function("roundtrip_object", roundtrip_object)?;
+    m.export_function("roundtrip_serde_json_value", roundtrip_serde_json_value)?;
+    m.export_function("roundtrip_with_dates", roundtrip_with_dates)?;
     Ok(())
 });


### PR DESCRIPTION
This is implemented by converting a JS Date into an object like `{ __neon_serde_date: <value of date (millis)>}`.

`Date` is deserialized into the aforementioned object and then serialized back from that object

`neon_serde::date::JsDate` is provided (behind feature flag `dates`) as a convenience type to consume the dates.